### PR TITLE
Start interval_fn loop after mods are loaded

### DIFF
--- a/zipper_detect.lua
+++ b/zipper_detect.lua
@@ -68,4 +68,4 @@ local function interval_fn()
     minetest.after(1, interval_fn)
 end
 
-interval_fn()
+minetest.register_on_mods_loaded(function() minetest.after(1, interval_fn) end)


### PR DESCRIPTION
Proposed fix for #1 
Better option would probably be tracking players with on_joinplayer / on_leaveplayer.