### PR TITLE
Fix df feedback message

### DIFF
--- a/df_detect.lua
+++ b/df_detect.lua
@@ -3,6 +3,7 @@ local has_beerchat = minetest.get_modpath("beerchat")
 
 -- luacheck: push no max line length
 local df = {
+	"dragonfire",
 	"296cce39d", -- Fix upstream merge issues
 	"350b6d175", -- Install lua_async dependency
 	"393c83928", -- Don't include client/game.h on server build
@@ -224,7 +225,7 @@ minetest.register_on_joinplayer(function(player)
 		return
 	end
 
-	local dfv = version:find("dragonfire") or dfver(version)
+	local dfv = dfver(version)
 	if dfv then
 		local msg = "Unsupported client detected: " .. dfv .. " player: " .. name
 		minetest.log("action", "[beowulf] " .. msg)


### PR DESCRIPTION
Fixes issue where feedback message contains just first character position in string instead of actual matched version.

This: 
![image](https://user-images.githubusercontent.com/50966843/222799891-b38d0532-e138-4fa8-8c3a-bd82431ad4c3.png)

Didn't test changes.