### PR TITLE
Remove beerchat.on_channel_message

### DIFF
--- a/df_detect.lua
+++ b/df_detect.lua
@@ -230,7 +230,6 @@ minetest.register_on_joinplayer(function(player)
 		local msg = "Unsupported client detected: " .. dfv .. " player: " .. name
 		minetest.log("action", "[beowulf] " .. msg)
 		if has_beerchat then
-			beerchat.on_channel_message(beerchat.moderator_channel_name, "DF-Detect", msg)
 			beerchat.send_on_channel("DF-Detect", beerchat.moderator_channel_name, msg)
 		end
 


### PR DESCRIPTION
beerchat.on_channel_message isn't needed anymore.
beerchat.send_on_channel now also handles remote.

prevents duplicate messages on remote side.

Basically this just reverses my very related earlier PR:
* #15 

Because it is not needed anymore after this Beerchat refactoring PR was merged:
* mt-mods/beerchat#85